### PR TITLE
Using initial upper case letter for methods and properties solving issue #1

### DIFF
--- a/NiWrapper.Net/CameraSettings.cs
+++ b/NiWrapper.Net/CameraSettings.cs
@@ -32,11 +32,11 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool CameraSettings_isValid(IntPtr objectHandler);
-        public new bool isValid
+        public new bool IsValid
         {
             get
             {
-                return base.isValid && CameraSettings_isValid(this.Handle);
+                return base.IsValid && CameraSettings_isValid(this.Handle);
             }
         }
 

--- a/NiWrapper.Net/CoordinateConverter.cs
+++ b/NiWrapper.Net/CoordinateConverter.cs
@@ -29,7 +29,7 @@ namespace OpenNIWrapper
         static extern OpenNI.Status CoordinateConverter_convertDepthToColor(
             IntPtr depthStream, IntPtr colorStream, int depthX, int depthY, UInt16 depthZ,
             ref int pColorX, ref int pColorY);
-        public static OpenNI.Status convertDepthToColor(VideoStream depthStream, VideoStream colorStream,
+        public static OpenNI.Status ConvertDepthToColor(VideoStream depthStream, VideoStream colorStream,
             int depthX, int depthY, UInt16 depthZ, out int pColorX, out int pColorY)
         {
             pColorX = 0;
@@ -55,7 +55,7 @@ namespace OpenNIWrapper
             return CoordinateConverter_convertDepthToWorld(depthStream.Handle,
                     depthX, depthY, depthZ, ref pWorldX, ref pWorldY, ref pWorldZ);
         }
-        public static OpenNI.Status convertDepthToWorld(VideoStream depthStream,
+        public static OpenNI.Status ConvertDepthToWorld(VideoStream depthStream,
             float depthX, float depthY, float depthZ, out float pWorldX, out float pWorldY, out float pWorldZ)
         {
             pWorldX = 0;
@@ -73,7 +73,7 @@ namespace OpenNIWrapper
         static extern OpenNI.Status CoordinateConverter_convertWorldToDepth_Float(
             IntPtr depthStream, float worldX, float worldY, float worldZ,
             ref float pDepthX, ref float pDepthY, ref float pDepthZ);
-        public static OpenNI.Status convertWorldToDepth(
+        public static OpenNI.Status ConvertWorldToDepth(
             VideoStream depthStream, float worldX, float worldY, float worldZ,
             out int pDepthX, out int pDepthY, out UInt16 pDepthZ)
         {
@@ -83,7 +83,7 @@ namespace OpenNIWrapper
             return CoordinateConverter_convertWorldToDepth(depthStream.Handle,
                 worldX, worldY, worldZ, ref pDepthX, ref pDepthY, ref pDepthZ);
         }
-        public static OpenNI.Status convertWorldToDepth(
+        public static OpenNI.Status ConvertWorldToDepth(
             VideoStream depthStream, float worldX, float worldY, float worldZ,
             out float pDepthX, out float pDepthY, out float pDepthZ)
         {

--- a/NiWrapper.Net/Device.cs
+++ b/NiWrapper.Net/Device.cs
@@ -59,7 +59,7 @@ namespace OpenNIWrapper
 
         public VideoStream CreateVideoStream(SensorType sensorType)
         {
-            if (!this.isValid)
+            if (!this.IsValid)
                 return null;
             if (!VideoStreams_Cache.ContainsKey(sensorType))
                 VideoStreams_Cache[sensorType] = VideoStream.Private_Create(this, sensorType);
@@ -70,7 +70,7 @@ namespace OpenNIWrapper
         static extern void Device_close(IntPtr objectHandler);
         public void Close()
         {
-            if (this.isValid)
+            if (this.IsValid)
                 foreach (VideoStream stream in VideoStreams_Cache.Values)
                     stream.Destroy();
             Device_close(this.Handle);
@@ -119,7 +119,7 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Device_isImageRegistrationModeSupported(IntPtr objectHandler, ImageRegistrationMode mode);
-        public bool isImageRegistrationModeSupported(ImageRegistrationMode mode)
+        public bool IsImageRegistrationModeSupported(ImageRegistrationMode mode)
         {
             return Device_isImageRegistrationModeSupported(this.Handle, mode);
         }
@@ -127,14 +127,14 @@ namespace OpenNIWrapper
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern OpenNI.Status Device_getProperty(IntPtr objectHandler,
             int propertyId, IntPtr data, out int dataSize);
-        public OpenNI.Status getProperty(int propertyId, IntPtr data, out int dataSize)
+        public OpenNI.Status GetProperty(int propertyId, IntPtr data, out int dataSize)
         {
             return Device_getProperty(this.Handle, propertyId, data, out dataSize);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern IntPtr Device_getSensorInfo(IntPtr objectHandler, SensorType sensorType);
-        public SensorInfo getSensorInfo(SensorType sensorType)
+        public SensorInfo GetSensorInfo(SensorType sensorType)
         {
             return new SensorInfo(Device_getSensorInfo(this.Handle, sensorType));
         }
@@ -142,21 +142,21 @@ namespace OpenNIWrapper
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern OpenNI.Status Device_setProperty(IntPtr objectHandler,
             int propertyId, IntPtr data, int dataSize);
-        public OpenNI.Status setProperty(int propertyId, IntPtr data, int dataSize)
+        public OpenNI.Status SetProperty(int propertyId, IntPtr data, int dataSize)
         {
             return Device_setProperty(this.Handle, propertyId, data, dataSize);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Device_hasSensor(IntPtr objectHandler, SensorType sensorType);
-        public bool hasSensor(SensorType sensorType)
+        public bool HasSensor(SensorType sensorType)
         {
             return Device_hasSensor(this.Handle, sensorType);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Device_isCommandSupported(IntPtr objectHandler, int commandId);
-        public bool isCommandSupported(int commandId)
+        public bool IsCommandSupported(int commandId)
         {
             return Device_isCommandSupported(this.Handle, commandId);
         }
@@ -164,14 +164,14 @@ namespace OpenNIWrapper
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern OpenNI.Status Device_invoke(IntPtr objectHandler,
             int commandId, IntPtr data, int dataSize);
-        public OpenNI.Status invoke(int commandId, IntPtr data, int dataSize)
+        public OpenNI.Status Invoke(int commandId, IntPtr data, int dataSize)
         {
             return Device_invoke(this.Handle, commandId, data, dataSize);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Device_isPropertySupported(IntPtr objectHandler, int propertyId);
-        public bool isPropertySupported(int propertyId)
+        public bool IsPropertySupported(int propertyId)
         {
             return Device_isPropertySupported(this.Handle, propertyId);
         }
@@ -223,11 +223,11 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Device_isValid(IntPtr objectHandler);
-        public new bool isValid
+        public new bool IsValid
         {
             get
             {
-                return base.isValid && Device_isValid(this.Handle);
+                return base.IsValid && Device_isValid(this.Handle);
             }
         }
 
@@ -241,7 +241,7 @@ namespace OpenNIWrapper
         {
             if (!_disposed)
             {
-                if (disposing && this.isValid)
+                if (disposing && this.IsValid)
                     this.Close();
 
                 this.Handle = IntPtr.Zero;

--- a/NiWrapper.Net/DeviceInfo.cs
+++ b/NiWrapper.Net/DeviceInfo.cs
@@ -32,7 +32,7 @@ namespace OpenNIWrapper
 
         public Device OpenDevice()
         {
-            if (!this.isValid)
+            if (!this.IsValid)
                 return null;
             return Device.Open(this.URI);
         }

--- a/NiWrapper.Net/OpenNIBase.cs
+++ b/NiWrapper.Net/OpenNIBase.cs
@@ -36,7 +36,7 @@ namespace OpenNIWrapper
             return this.Handle == obj;
         }
 
-        public bool isValid
+        public bool IsValid
         {
             get
             {

--- a/NiWrapper.Net/PlaybackControl.cs
+++ b/NiWrapper.Net/PlaybackControl.cs
@@ -32,24 +32,24 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool PlaybackControl_isValid(IntPtr objectHandler);
-        public new bool isValid
+        public new bool IsValid
         {
             get
             {
-                return base.isValid && PlaybackControl_isValid(this.Handle);
+                return base.IsValid && PlaybackControl_isValid(this.Handle);
             }
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern int PlaybackControl_getNumberOfFrames(IntPtr objectHandler, IntPtr videoStream);
-        public int getNumberOfFrames(VideoStream stream)
+        public int GetNumberOfFrames(VideoStream stream)
         {
             return PlaybackControl_getNumberOfFrames(this.Handle, stream.Handle);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern OpenNI.Status PlaybackControl_seek(IntPtr objectHandler, IntPtr videoStream, int frameIndex);
-        public OpenNI.Status seek(VideoStream stream, int frameIndex)
+        public OpenNI.Status Seek(VideoStream stream, int frameIndex)
         {
             return PlaybackControl_seek(this.Handle, stream.Handle, frameIndex);
         }

--- a/NiWrapper.Net/Recorder.cs
+++ b/NiWrapper.Net/Recorder.cs
@@ -74,11 +74,11 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool Recorder_isValid(IntPtr objectHandler);
-        public new bool isValid
+        public new bool IsValid
         {
             get
             {
-                return base.isValid && Recorder_isValid(this.Handle);
+                return base.IsValid && Recorder_isValid(this.Handle);
             }
         }
 
@@ -99,7 +99,7 @@ namespace OpenNIWrapper
         {
             if (!_disposed)
             {
-                if (disposing && this.isValid)
+                if (disposing && this.IsValid)
                     this.Destroy();
 
                 this.Handle = IntPtr.Zero;

--- a/NiWrapper.Net/SensorInfo.cs
+++ b/NiWrapper.Net/SensorInfo.cs
@@ -32,7 +32,7 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern Device.SensorType SensorInfo_getSensorType(IntPtr objectHandler);
-        public Device.SensorType getSensorType()
+        public Device.SensorType GetSensorType()
         {
             return SensorInfo_getSensorType(this.Handle);
         }
@@ -41,7 +41,7 @@ namespace OpenNIWrapper
         static extern WrapperArray SensorInfo_getSupportedVideoModes(IntPtr objectHandler);
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern IntPtr SensorInfo_destroyVideoModesArray(WrapperArray array);
-        public VideoMode[] getSupportedVideoModes()
+        public VideoMode[] GetSupportedVideoModes()
         {
             WrapperArray csa = SensorInfo_getSupportedVideoModes(this.Handle);
             IntPtr[] array = new IntPtr[csa.Size];
@@ -54,7 +54,7 @@ namespace OpenNIWrapper
         }
         public override string ToString()
         {
-            return this.getSensorType().ToString();
+            return this.GetSensorType().ToString();
         }
     }
 }

--- a/NiWrapper.Net/VideoFrameRef.cs
+++ b/NiWrapper.Net/VideoFrameRef.cs
@@ -143,7 +143,7 @@ namespace OpenNIWrapper
             }
         }
 
-        public Bitmap toBitmap(copyBitmapOptions options = copyBitmapOptions.None)
+        public Bitmap ToBitmap(copyBitmapOptions options = copyBitmapOptions.None)
         {
             System.Drawing.Imaging.PixelFormat format = System.Drawing.Imaging.PixelFormat.Format24bppRgb;
             switch (this.VideoMode.DataPixelFormat)
@@ -168,13 +168,13 @@ namespace OpenNIWrapper
             if (format == PixelFormat.Format8bppIndexed)
                 for (int i = 0; i < 256; i++)
                     destination.Palette.Entries[i] = Color.FromArgb(i, i, i);
-            updateBitmap(destination, options);
+            UpdateBitmap(destination, options);
             return destination;
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern void VideoFrameRef_copyDataTo(IntPtr objectHandler, IntPtr dstData, int dstStride, copyBitmapOptions options);
-        public void updateBitmap(Bitmap image, copyBitmapOptions options = copyBitmapOptions.None)
+        public void UpdateBitmap(Bitmap image, copyBitmapOptions options = copyBitmapOptions.None)
         {
                 if (image.Width != this.FrameSize.Width || image.Height != this.FrameSize.Height)
                     throw new ArgumentException("Bitmap size if not acceptable.");
@@ -279,7 +279,7 @@ namespace OpenNIWrapper
         {
             if (!_disposed)
             {
-                if (disposing && this.isValid)
+                if (disposing && this.IsValid)
                     this.Release();
 
                 this.Handle = IntPtr.Zero;

--- a/NiWrapper.Net/VideoStream.cs
+++ b/NiWrapper.Net/VideoStream.cs
@@ -45,7 +45,7 @@ namespace OpenNIWrapper
         static extern void VideoStream_destroy(IntPtr objectHandler);
         internal void Destroy()
         {
-            if (this.isValid)
+            if (this.IsValid)
                 VideoStream_destroy(this.Handle);
             Common.DeleteObject(this);
         }
@@ -166,7 +166,7 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool VideoStream_isCroppingSupported(IntPtr objectHandler);
-        public bool isCroppingSupported
+        public bool IsCroppingSupported
         {
             get
             {
@@ -247,7 +247,7 @@ namespace OpenNIWrapper
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool VideoStream_isCommandSupported(IntPtr objectHandler, int commandId);
-        public bool isCommandSupported(int commandId)
+        public bool IsCommandSupported(int commandId)
         {
             return VideoStream_isCommandSupported(this.Handle, commandId);
         }
@@ -255,25 +255,25 @@ namespace OpenNIWrapper
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern OpenNI.Status VideoStream_invoke(IntPtr objectHandler,
             int commandId, IntPtr data, int dataSize);
-        public OpenNI.Status invoke(int commandId, IntPtr data, int dataSize)
+        public OpenNI.Status Invoke(int commandId, IntPtr data, int dataSize)
         {
             return VideoStream_invoke(this.Handle, commandId, data, dataSize);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool VideoStream_isPropertySupported(IntPtr objectHandler, int propertyId);
-        public bool isPropertySupported(int propertyId)
+        public bool IsPropertySupported(int propertyId)
         {
             return VideoStream_isPropertySupported(this.Handle, propertyId);
         }
 
         [DllImport("NiWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         static extern bool VideoStream_isValid(IntPtr objectHandler);
-        public new bool isValid
+        public new bool IsValid
         {
             get
             {
-                return base.isValid && VideoStream_isValid(this.Handle);
+                return base.IsValid && VideoStream_isValid(this.Handle);
             }
         }
 
@@ -293,7 +293,7 @@ namespace OpenNIWrapper
 
         public override string ToString()
         {
-            return this.SensorInfo.getSensorType().ToString();
+            return this.SensorInfo.GetSensorType().ToString();
         }
     }
 }

--- a/NiWrapper.NiTE.Net/HandTracker.cs
+++ b/NiWrapper.NiTE.Net/HandTracker.cs
@@ -55,7 +55,7 @@ namespace NiTEWrapper
         public static HandTracker Create(Device device = null)
         {
             IntPtr deviceHandle = IntPtr.Zero;
-            if (device != null && device.isValid)
+            if (device != null && device.IsValid)
                 deviceHandle = device.Handle;
             IntPtr handle;
             NiTE.throwIfError(HandTracker_create(out handle, deviceHandle));

--- a/NiWrapper.NiTE.Net/UserTracker.cs
+++ b/NiWrapper.NiTE.Net/UserTracker.cs
@@ -55,7 +55,7 @@ namespace NiTEWrapper
         public static UserTracker Create(Device device = null)
         {
             IntPtr deviceHandle = IntPtr.Zero;
-            if (device != null && device.isValid)
+            if (device != null && device.IsValid)
                 deviceHandle = device.Handle;
             IntPtr handle;
             NiTE.throwIfError(UserTracker_create(out handle, deviceHandle));

--- a/Samples/ConsoleTest/Program.cs
+++ b/Samples/ConsoleTest/Program.cs
@@ -31,19 +31,19 @@ namespace ConsoleTest
             using (device = Device.Open(null,"lr")) // lean init and no reset flags
             {	
                 VideoStream depth;
-                SensorInfo sensorInfo = device.getSensorInfo(Device.SensorType.DEPTH);
+                SensorInfo sensorInfo = device.GetSensorInfo(Device.SensorType.DEPTH);
 	            if (sensorInfo != null)
 	            {
 		            depth = VideoStream.Create(device, OpenNIWrapper.Device.SensorType.DEPTH);
 	            }
 
 
-                if (device.hasSensor(Device.SensorType.DEPTH) &&
-                    device.hasSensor(Device.SensorType.COLOR))
+                if (device.HasSensor(Device.SensorType.DEPTH) &&
+                    device.HasSensor(Device.SensorType.COLOR))
                 {
                     VideoStream depthStream = device.CreateVideoStream(Device.SensorType.DEPTH);
                     VideoStream colorStream = device.CreateVideoStream(Device.SensorType.COLOR);
-                    if (depthStream.isValid && colorStream.isValid)
+                    if (depthStream.IsValid && colorStream.IsValid)
                     {
                         if (!HandleError(depthStream.Start())) { OpenNI.Shutdown(); return; }
                         if (!HandleError(colorStream.Start())) { OpenNI.Shutdown(); return; }

--- a/Samples/NiViewer.Net/frm_Main.cs
+++ b/Samples/NiViewer.Net/frm_Main.cs
@@ -60,9 +60,9 @@ namespace NiViewer.Net
             {
                 if (currentDevice != null) currentDevice.Dispose();
                 currentDevice = ((DeviceInfo)cb_devices.SelectedItem).OpenDevice();
-                if (currentDevice.hasSensor(Device.SensorType.COLOR)) cb_sensor.Items.Add("Color");
-                if (currentDevice.hasSensor(Device.SensorType.DEPTH)) cb_sensor.Items.Add("Depth");
-                if (currentDevice.hasSensor(Device.SensorType.IR)) cb_sensor.Items.Add("IR");
+                if (currentDevice.HasSensor(Device.SensorType.COLOR)) cb_sensor.Items.Add("Color");
+                if (currentDevice.HasSensor(Device.SensorType.DEPTH)) cb_sensor.Items.Add("Depth");
+                if (currentDevice.HasSensor(Device.SensorType.IR)) cb_sensor.Items.Add("IR");
             }
         }
         VideoStream currentSensor;
@@ -71,7 +71,7 @@ namespace NiViewer.Net
             cb_videomode.Items.Clear();
             if (cb_sensor.SelectedItem != null && currentDevice != null)
             {
-                if (currentSensor != null && currentSensor.isValid) currentSensor.Stop();
+                if (currentSensor != null && currentSensor.IsValid) currentSensor.Stop();
                 switch ((string)(cb_sensor.SelectedItem))
                 {
                     case "Color":
@@ -86,7 +86,7 @@ namespace NiViewer.Net
                     default:
                         break;
                 }
-                VideoMode[] videoModes = currentSensor.SensorInfo.getSupportedVideoModes();
+                VideoMode[] videoModes = currentSensor.SensorInfo.GetSupportedVideoModes();
                 for (int i = 0; i < videoModes.Length; i++)
                 {
                     if (videoModes[i].DataPixelFormat == VideoMode.PixelFormat.GRAY16 ||
@@ -100,7 +100,7 @@ namespace NiViewer.Net
 
         private void btn_submit_Click(object sender, EventArgs e)
         {
-            if (currentSensor != null && currentSensor.isValid && cb_videomode.SelectedItem != null)
+            if (currentSensor != null && currentSensor.IsValid && cb_videomode.SelectedItem != null)
             {
                 currentSensor.Stop();
                 currentSensor.onNewFrame -= currentSensor_onNewFrame;
@@ -127,11 +127,11 @@ namespace NiViewer.Net
         
         void currentSensor_onNewFrame(VideoStream vStream)
         {
-            if (vStream.isValid && vStream.isFrameAvailable())
+            if (vStream.IsValid && vStream.isFrameAvailable())
             {
                 using (VideoFrameRef frame = vStream.readFrame())
                 {
-                    if (frame.isValid)
+                    if (frame.IsValid)
                     {
                         VideoFrameRef.copyBitmapOptions options = VideoFrameRef.copyBitmapOptions.Force24BitRGB | VideoFrameRef.copyBitmapOptions.DepthFillShadow;
                         if (cb_invert.Checked)
@@ -148,11 +148,11 @@ namespace NiViewer.Net
                             /////////////////////// with multi-thread situations.
                             try
                             {
-                                frame.updateBitmap(bitmap, options);
+                                frame.UpdateBitmap(bitmap, options);
                             }
                             catch (Exception) // Happens when our Bitmap object is not compatible with returned Frame
                             {
-                                bitmap = frame.toBitmap(options);
+                                bitmap = frame.ToBitmap(options);
                             }
                             /////////////////////// END NOTE
 


### PR DESCRIPTION
Using initial upper case letter for methods and properties in the c# interface solving issue #1.
