### PR TITLE
Upgrading NuGet.Output package

### DIFF
--- a/NiWrapper.Net/NiWrapper.Net.x64.nuspec
+++ b/NiWrapper.Net/NiWrapper.Net.x64.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>.Net Wrapper for OpenNI 2</description>
     <dependencies>
-      <dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.2" />
+      <dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.7" />
     </dependencies>
   </metadata>
   <files>

--- a/NiWrapper.Net/NiWrapper.Net.x86.nuspec
+++ b/NiWrapper.Net/NiWrapper.Net.x86.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>.Net Wrapper for OpenNI 2</description>
     <dependencies>
-      <dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.2" />
+      <dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.7" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
The 1.0.2 version contains a bug when trying to do a package "restore"
that has later been fixed. As I'm writing this 1.0.7 is the latest
version.
